### PR TITLE
Only report prefer_goto on return statements

### DIFF
--- a/cstyle.py
+++ b/cstyle.py
@@ -174,7 +174,7 @@ class CStyle(object):
                 self._n_returns = 0
             elif node.kind == clang.cindex.CursorKind.RETURN_STMT:
                 self._n_returns = self._n_returns + 1
-            invalid = self._n_returns > 1
+                invalid = self._n_returns > 1
             if invalid:
                 reason = 'Only 1 return statement per function (prefer_goto)'
         return invalid, reason, name


### PR DESCRIPTION
I get a "Only 1 return statement per function (prefer_goto)" on every statement after the second return statement, which is undesirable.  This PR fixes that by only reporting an error on the extra return statements.